### PR TITLE
Backport upstream fixes for filter preview zoom and navigation slider, unbundle libmp4v2

### DIFF
--- a/avidemux-2.6.16-filter-preview.patch
+++ b/avidemux-2.6.16-filter-preview.patch
@@ -1,0 +1,379 @@
+commit b77bac1b214215eb30d86d426018e95d7b0231ce
+Author: mean <fixounet@free.fr>
+Date:   Sun Jan 1 14:19:49 2017 +0100
+
+    [autoZoom] if unzooming make sure it is at least 1.5
+
+ avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+commit 1fcc43c2defde1fad7bfbba41b40ec00d0a0e868
+Author: mean <fixounet@free.fr>
+Date:   Mon Jan 2 18:58:45 2017 +0100
+
+    [flyDialog] Begin to simplify zoom computation
+
+ avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h |  6 +-
+ avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp      | 99 +++++++++++++++++++------
+ 2 files changed, 79 insertions(+), 26 deletions(-)
+commit 6803a6185e7f9abe529b6f7f05eae5b904c92407
+Author: mean <fixounet@free.fr>
+Date:   Tue Jan 3 07:52:48 2017 +0100
+
+    [flyDialog] Tweak a bit more autozoom
+
+ avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp                   | 12 +++++++-----
+ .../qt4/ADM_userInterfaces/ADM_filters/seekablePreview.ui    |  8 ++++----
+ 2 files changed, 11 insertions(+), 9 deletions(-)
+commit befdc396c667c730cf0e91f3ce261369aee60e80
+Author: eumagga0x2a <eumagga0x2a@users.noreply.github.com>
+Date:   Tue Jan 3 15:24:00 2017 +0100
+
+    [flyDialog] Fix navigation slider (WIP), add missing tooltips
+
+ avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h |  4 ++
+ avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp      | 68 +++++++++++++++++++++----
+ 2 files changed, 61 insertions(+), 11 deletions(-)
+
+diff -uprN a/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h b/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
+--- a/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h	2016-12-31 08:10:19.000000000 +0100
++++ b/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h	2017-01-03 20:41:52.197003667 +0100
+@@ -81,7 +81,7 @@ class ADM_UIQT46_EXPORT ADM_flyDialog :
+           ResizeMethod  _resizeMethod;
+           uint64_t      lastPts;
+           double        _computedZoom;
+-          
++          int           _usedWidth, _usedHeight;
+           
+           ADM_coreVideoFilter *_in;
+       
+@@ -117,7 +117,9 @@ protected:
+   virtual ADM_colorspace     toRgbColor(void);
+           void               updateZoom(void);
+           void               EndConstructor(void);
+-          uint8_t            cleanup(void);          
++          uint8_t            cleanup(void);  
++          bool               initializeSize();
++          float              calcZoomToBeDisplayable(uint32_t imageWidth, uint32_t imageHeight);
+   /* Filter dependant : you have to implement them*/
+ //
+            virtual           void resetScaler(void)=0; // dont bother, implemented by yuv or rgb subclass
+@@ -143,7 +145,11 @@ public:
+   virtual void     postInit(uint8_t reInit);
+ public:  
+   virtual uint8_t  sliderChanged(void);
++  virtual void     updateSlider(void);
+   virtual bool     goToTime(uint64_t tme);
++
++private:
++  virtual bool     nextImageInternal(void);
+   
+ public slots:
+         virtual bool nextImage(void);
+diff -uprN a/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp b/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
+--- a/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp	2016-12-31 08:10:19.000000000 +0100
++++ b/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp	2017-01-03 20:41:52.197003667 +0100
+@@ -124,14 +124,18 @@ ADM_flyDialog::~ADM_flyDialog(void)
+ }
+ 
+ /**
+-      \fn sliderChanged
+-      \brief callback to handle image changes
++    \fn goToTime
+ */
+ bool    ADM_flyDialog::goToTime(uint64_t tme)
+ {
+      _in->goToTime(tme);
+-     return nextImage();
++     return nextImageInternal();
+ }
++
++/**
++    \fn sliderChanged
++    \brief callback to handle image changes
++*/
+ uint8_t    ADM_flyDialog::sliderChanged(void)
+ {
+   uint32_t fn= sliderGet();
+@@ -205,9 +209,10 @@ bool        ADM_flyDialog::addControl(QH
+         pushButton_back1mn->setToolTip(QApplication::translate("seekablePreviewDialog", "Back one minute", 0));
+         pushButton_back1mn->setText(QApplication::translate("seekablePreviewDialog", "<<", 0));
+         pushButton_play->setText(QApplication::translate("seekablePreviewDialog", "Play", 0));
+-        pushButton_next->setStatusTip(QApplication::translate("seekablePreviewDialog", "next image", 0));
++        pushButton_next->setToolTip(QApplication::translate("seekablePreviewDialog", "Next image", 0));
+         pushButton_next->setText(QApplication::translate("seekablePreviewDialog", ">", 0));
+         pushButton_fwd1mn->setText(QApplication::translate("seekablePreviewDialog", ">>", 0));
++        pushButton_fwd1mn->setToolTip(QApplication::translate("seekablePreviewDialog", "Forward one minute", 0));
+         radioButton_autoZoom->setText(QApplication::translate("seekablePreviewDialog", "A&utoZoom", 0));
+         
+         QObject::connect(pushButton_next ,SIGNAL(clicked()),this,SLOT(nextImage()));
+@@ -232,9 +237,9 @@ uint64_t ADM_flyDialog::getCurrentPts()
+     return lastPts;
+ }
+ /**
+-    \fn nextImage
++    \fn nextImageInternal
+ */
+-bool ADM_flyDialog::nextImage(void)
++bool ADM_flyDialog::nextImageInternal(void)
+ {
+     uint32_t frameNumber;
+     if(!_in->getNextFrame(&frameNumber,_yuvBuffer))
+@@ -248,6 +253,88 @@ bool ADM_flyDialog::nextImage(void)
+     process();
+     return display(_rgbByteBufferDisplay.at(0));
+ }
++
++/**
++    \fn nextImage
++*/
++bool ADM_flyDialog::nextImage(void)
++{
++    QSlider  *slide=(QSlider *)_slider;
++    ADM_assert(slide);
++    bool oldState=slide->blockSignals(true);
++    bool r=nextImageInternal();
++    if(r)
++        updateSlider();
++    slide->blockSignals(oldState);
++    return r;
++}
++
++/**
++ * 
++ * @return 
++ */
++bool ADM_flyDialog::initializeSize()
++{
++    _canvas->resize(1,1);
++    QSize qsize= _canvas->parentWidget()->parentWidget()->size();
++    //_usedWidth = qsize.width();
++    // Normally there is nothing interesting left and right, we can use a hardcoded value
++    _usedWidth=64;
++    _usedHeight= 32+qsize.height(); // keep a border margin
++    
++     if (_resizeMethod != RESIZE_NONE) 
++    {
++        _zoom = calcZoomFactor();
++        if (_zoom == 1) 
++        {
++            _resizeMethod = RESIZE_NONE;
++        }
++    }
++    if (_resizeMethod == RESIZE_NONE) 
++    {
++        _zoom = 1;
++        _zoomW = _w;
++        _zoomH = _h;
++    } else 
++    {
++        _zoomW = uint32_t(_w * _zoom);
++        _zoomH = uint32_t(_h * _zoom);
++    }
++    
++    
++    ADM_info("xAutoZoom : base size= %d x %d\n",_usedWidth,_usedHeight);
++    return true;
++}
++/**
++ * \brief Calculate the zoom ratio required to fit the whole image on the screen.
++ * @param imageWidth
++ * @param imageHeight
++ * @return 
++ */
++float ADM_flyDialog::calcZoomToBeDisplayable( uint32_t imageWidth, uint32_t imageHeight)
++{
++        uint32_t screenWidth, screenHeight;
++        QWidget *topWindow=_canvas->parentWidget()->parentWidget();
++        UI_getPhysicalScreenSize(topWindow, &screenWidth, &screenHeight);
++        
++        // Usable width/height
++        int usableWidth =(int)screenWidth -_usedWidth;
++        int usableHeight=(int)screenHeight-_usedHeight;
++        
++        if(usableWidth<160) usableWidth=160;
++        if(usableHeight<160) usableHeight=160;
++        
++
++        float widthRatio  = (float)usableWidth / (float)imageWidth;
++        float heightRatio = (float)usableHeight / (float)imageHeight;
++
++        ADM_info("autoZoom : Raw w=%f h=%f\n",widthRatio,heightRatio);
++        
++        float r= (widthRatio < heightRatio ? widthRatio : heightRatio);
++        return r;
++		
++}
++
+ //************************************
+ // Implement the specific part
+ // i.e. yuv processing or RGB processing
+@@ -258,6 +345,7 @@ bool ADM_flyDialog::nextImage(void)
+ {
+         _yuvBufferOut=new ADMImageDefault(_w,_h);
+         yuvToRgb=NULL;  
++        initializeSize();
+         updateZoom();
+         postInit(false);
+ }
+@@ -294,6 +382,7 @@ ADM_flyDialogRgb::ADM_flyDialogRgb(QDial
+      yuv2rgb =new ADMColorScalerSimple(_w,_h,ADM_COLOR_YV12,
+                 toRgbColor());
+     rgb2rgb=NULL;
++    initializeSize();
+     updateZoom();
+     postInit(false);
+ 
+@@ -335,7 +424,8 @@ bool ADM_flyDialogRgb::process(void)
+     return true;
+ }
+ 
+-extern float UI_calcZoomToFitScreen(QWidget* window, QWidget* canvas, uint32_t imageWidth, uint32_t imageHeight);
++
++
+ 
+ /**
+     \fn    FlyDialogEventFilter
+@@ -377,9 +467,10 @@ bool FlyDialogEventFilter::eventFilter(Q
+                               ADM_QCanvas *canvas, QSlider *slider,  ResizeMethod resizeMethod)
+ {  
+     ADM_assert(canvas);
+-
+-    if (slider)
+-            ADM_assert(in);
++    {
++        ADM_assert(in);
++        slider->setMaximum(ADM_FLY_SLIDER_MAX);
++    }
+     _parent=parent;
+     _w = width;
+     _h = height;    
+@@ -391,25 +482,9 @@ bool FlyDialogEventFilter::eventFilter(Q
+     _resizeMethod = resizeMethod;
+     _zoomChangeCount = 0;        
+     _yuvBuffer=new ADMImageDefault(_w,_h);
++    _usedWidth= _usedHeight=0;
+     lastPts=0;
+-    if (_resizeMethod != RESIZE_NONE) 
+-    {
+-        _zoom = calcZoomFactor();
+-        if (_zoom == 1) 
+-        {
+-            _resizeMethod = RESIZE_NONE;
+-        }
+-    }
+-    if (_resizeMethod == RESIZE_NONE) 
+-    {
+-        _zoom = 1;
+-        _zoomW = _w;
+-        _zoomH = _h;
+-    } else 
+-    {
+-        _zoomW = uint32_t(_w * _zoom);
+-        _zoomH = uint32_t(_h * _zoom);
+-    }
++   
+     
+     connect(&timer,SIGNAL(timeout()),this,SLOT(timeout()));
+     timer.setSingleShot(true);
+@@ -451,22 +526,22 @@ void ADM_flyDialog::postInit(uint8_t reI
+     \fn    calcZoomFactor
+     \brief
+ */
+-
+ float ADM_flyDialog::calcZoomFactor(void)
+ {
++#define APPROXIMATE 20.
+     if(_computedZoom) return _computedZoom;
+     double zoom;
+-    zoom=UI_calcZoomToFitScreen(((ADM_QCanvas*)_canvas)->parentWidget()->parentWidget(), ((ADM_QCanvas*)_canvas)->parentWidget(), _w, _h);
++    zoom=calcZoomToBeDisplayable(_w, _h);
+     // Find the closest integer
+     // zoom it ?
+-    if((zoom+0.3)>1)
++    if((zoom)>1)
+     {
+-        _computedZoom=floor(2*(zoom+0.3))/2;
++        _computedZoom=floor(APPROXIMATE*(zoom))/APPROXIMATE;
+         ADM_info("AutoZoom %f ->%f \n",(float)zoom,(float)_computedZoom);
+         return _computedZoom;
+     }
+     double invertZoom=1/zoom;
+-    _computedZoom=2./floor((2*(invertZoom+0.3)));
++    _computedZoom=APPROXIMATE/floor((1+APPROXIMATE*(invertZoom)));
+     ADM_info("AutoZoom 1/%f\n",(float)(1./_computedZoom));
+     return _computedZoom;
+     
+@@ -513,6 +588,24 @@ uint8_t     ADM_flyDialog::sliderSet(uin
+   slide->setValue(value);
+   return 1; 
+ }
++
++/**
++    \fn    updateSlider
++    \brief
++*/
++void ADM_flyDialog::updateSlider(void)
++{
++    ADM_assert(_in);
++    uint64_t dur=_in->getInfo()->totalDuration;
++    uint64_t pts=getCurrentPts();
++    double pos;
++    pos=pts;
++    pos/=dur;
++    pos*=ADM_FLY_SLIDER_MAX;
++    pos+=0.5; // round up
++    sliderSet((uint32_t)pos);
++}
++
+ /**
+     \fn    isRgbInverted
+     \brief
+@@ -534,6 +627,7 @@ void ADM_flyDialog::backOneMinute(void)
+     if(pts<JUMP_LENGTH) pts=0;
+     else pts-=JUMP_LENGTH;
+     goToTime(pts);
++    updateSlider();
+ }
+ /**
+  * 
+@@ -543,18 +637,21 @@ void ADM_flyDialog::fwdOneMinute(void)
+     uint64_t pts=getCurrentPts();
+     pts+=JUMP_LENGTH;
+     goToTime(pts);
+-
++    updateSlider();
+ }
+ /**
+  * 
+  */
+ void ADM_flyDialog::play(bool state)
+ {
++    QSlider *slide=(QSlider *)_slider;
++    ADM_assert(slide);
+     if(state)
+     {
+        pushButton_back1mn->setEnabled(false);
+        pushButton_fwd1mn->setEnabled(false);
+        pushButton_next->setEnabled(false);
++       slide->setEnabled(false);
+        timer.start();
+     }else
+     {
+@@ -562,6 +659,8 @@ void ADM_flyDialog::play(bool state)
+         pushButton_back1mn->setEnabled(true);
+         pushButton_fwd1mn->setEnabled(true);
+         pushButton_next->setEnabled(true);
++        updateSlider();
++        slide->setEnabled(true);
+     }
+     
+ }
+@@ -589,7 +688,7 @@ void ADM_flyDialog::autoZoom(bool state)
+ void ADM_flyDialog::timeout()
+ {
+     
+-    bool r=nextImage();
++    bool r=nextImageInternal();
+     if(r)
+     {
+         timer.start();

--- a/avidemux-2.6.16-mp4muxer-eac3.patch
+++ b/avidemux-2.6.16-mp4muxer-eac3.patch
@@ -1,0 +1,25 @@
+commit fbb1eb67f11dd35decd75ee295feee22a8340a2c
+Author: mean <fixounet@free.fr>
+Date:   Tue Jan 3 19:17:39 2017 +0100
+
+    [MP4/muxer] Allow eac3 (fiftyplus)
+---
+ avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp b/avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp
+index 952cf42..192bff3 100644
+--- a/avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp
++++ b/avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp
+@@ -68,9 +68,9 @@ bool muxerMP4::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,A
+         for(int i=0;i<nbAudioTrack;i++)
+         {
+             uint32_t acc=a[i]->getInfo()->encoding;
+-            if(acc!=WAV_MP2 && acc!=WAV_MP3 && acc!=WAV_AAC && acc!=WAV_AC3)
++            if(acc!=WAV_MP2 && acc!=WAV_MP3 && acc!=WAV_AAC && acc!=WAV_AC3 && acc!=WAV_EAC3)
+             {
+-                GUI_Error_HIG(QT_TRANSLATE_NOOP("mp4muxer","Unsupported"),QT_TRANSLATE_NOOP("mp4muxer","Only AAC, AC3, and mpegaudio supported for audio"));
++                GUI_Error_HIG(QT_TRANSLATE_NOOP("mp4muxer","Unsupported"),QT_TRANSLATE_NOOP("mp4muxer","Only AAC, AC3, E-AC3 and mpegaudio supported for audio"));
+                 return false;
+             }
+         }

--- a/avidemux-2.6.16-unbundle-libmp4v2.patch
+++ b/avidemux-2.6.16-unbundle-libmp4v2.patch
@@ -1,0 +1,102 @@
+commit aea8957dd42ec3ce83a921a2317e361c5a72b874
+Author: eumagga0x2a <eumagga0x2a@users.noreply.github.com>
+Date:   Tue Jan 3 22:16:58 2017 +0100
+
+    [build/plugins] Allow system libmp4v2
+---
+ avidemux_plugins/ADM_muxers/muxerMp4v2/CMakeLists.txt | 12 +++++++++---
+ avidemux_plugins/CMakeLists.txt                       |  8 ++++++++
+ bootStrap.bash                                        |  8 ++++++++
+ 3 files changed, 25 insertions(+), 3 deletions(-)
+
+diff --git a/avidemux_plugins/ADM_muxers/muxerMp4v2/CMakeLists.txt b/avidemux_plugins/ADM_muxers/muxerMp4v2/CMakeLists.txt
+index 55639ed..c2139de 100644
+--- a/avidemux_plugins/ADM_muxers/muxerMp4v2/CMakeLists.txt
++++ b/avidemux_plugins/ADM_muxers/muxerMp4v2/CMakeLists.txt
+@@ -6,11 +6,17 @@ SET(ADM_mp4v2_SRCS
+ 	muxerMp4v2Video.cpp
+ 	muxerMp4v2Config.cpp
+ )
+-SUBDIRS(libmp4v2)
++IF(NOT USE_EXTERNAL_MP4V2)
++        ADD_SUBDIRECTORY(libmp4v2)
++ENDIF()
+ 
+ ADD_LIBRARY(ADM_mx_mp4v2 SHARED ${ADM_mp4v2_SRCS})
+-TARGET_LINK_LIBRARIES(ADM_mx_mp4v2 ADM_libmp4v2)
++IF(USE_EXTERNAL_MP4V2)
++        TARGET_LINK_LIBRARIES(ADM_mx_mp4v2 ${MP4V2_LIBRARIES})
++ELSE()
++        TARGET_LINK_LIBRARIES(ADM_mx_mp4v2 ADM_libmp4v2)
++        INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/libmp4v2/include/)
++ENDIF()
+ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/libmp4v2/include/)
+ INIT_MUXER(ADM_mx_mp4v2)
+ INSTALL_MUXER(ADM_mx_mp4v2)
+diff --git a/avidemux_plugins/CMakeLists.txt b/avidemux_plugins/CMakeLists.txt
+index 272f786..9650db5 100644
+--- a/avidemux_plugins/CMakeLists.txt
++++ b/avidemux_plugins/CMakeLists.txt
+@@ -70,6 +70,7 @@ INCLUDE_DIRECTORIES("${AVIDEMUX_SEARCH_INCLUDE_DIR}/avidemux/2.6")
+ OPTION(USE_EXTERNAL_LIBASS "Use system installed libass library." OFF)
+ OPTION(USE_EXTERNAL_LIBMAD "Use system installed libmad library." OFF)
+ OPTION(USE_EXTERNAL_LIBA52 "Use system installed liba52 library." OFF)
++OPTION(USE_EXTERNAL_MP4V2 "Use system installed libmp4v2 library." OFF)
+ 
+ INCLUDE(FindPkgConfig)
+ 
+@@ -93,6 +94,13 @@ IF(USE_EXTERNAL_LIBA52)
+         INCLUDE_DIRECTORIES(SYSTEM ${LIBA52_INCLUDE_DIR})
+ ENDIF()
+ 
++# libmp4v2
++IF(USE_EXTERNAL_MP4V2)
++        FIND_PATH(MP4V2_INCLUDE_DIR mp4v2/mp4v2.h)
++        FIND_LIBRARY(MP4V2_LIBRARIES mp4v2)
++        INCLUDE_DIRECTORIES(SYSTEM ${MP4V2_INCLUDE_DIR})
++ENDIF()
++
+ IF (FRESH_BUILD)
+ 	MESSAGE("")
+ ENDIF (FRESH_BUILD)
+diff --git a/bootStrap.bash b/bootStrap.bash
+index 86810d1..7d21b61 100644
+--- a/bootStrap.bash
++++ b/bootStrap.bash
+@@ -26,6 +26,7 @@ fi
+ external_libass=0
+ external_liba52=0
+ external_libmad=0
++external_libmp4v2=0
+ 
+ fail()
+ {
+@@ -120,6 +121,7 @@ usage()
+         echo "  --with-system-libass  : Use system libass instead of the bundled one"
+         echo "  --with-system-liba52  : Use system liba52 (a52dec) instead of the bundled one"
+         echo "  --with-system-libmad  : Use system libmad instead of the bundled one"
++        echo "  --with-system-libmp4v2: Use system libmp4v2 instead of the bundled one"
+ 	echo "The end result will be in the install folder. You can then copy it to / or whatever"
+         config 
+ 
+@@ -239,6 +241,9 @@ while [ $# != 0 ] ;do
+          --with-system-libmad)
+                 external_libmad=1
+              ;;
++         --with-system-libmp4v2)
++                external_libmp4v2=1
++             ;;
+         *)
+                 echo "unknown parameter $config_option"
+                 usage
+@@ -263,6 +268,9 @@ fi
+ if [ "x$external_libmad" = "x1" ]; then
+     export EXTRA_CMAKE_DEFS="-DUSE_EXTERNAL_LIBMAD=true $EXTRA_CMAKE_DEFS"
+ fi
++if [ "x$external_libmp4v2" = "x1" ]; then
++    export EXTRA_CMAKE_DEFS="-DUSE_EXTERNAL_MP4V2=true $EXTRA_CMAKE_DEFS"
++fi
+ echo "Top dir : $TOP"
+ echo "Fake installation directory=$FAKEROOT_DIR"
+ if [ "x$debug" = "x1" ] ; then echo   

--- a/avidemux.spec
+++ b/avidemux.spec
@@ -14,6 +14,9 @@ Source0:        http://downloads.sourceforge.net/%{name}/%{name}_%{version}.tar.
 Source1:        avidemux-qt.desktop
 
 Patch0:         avidemux-2.6.15-disable-vpx-decoder-plugin.patch
+Patch1:         avidemux-2.6.16-filter-preview.patch
+Patch2:         avidemux-2.6.16-unbundle-libmp4v2.patch
+Patch3:         avidemux-2.6.16-mp4muxer-eac3.patch
 
 # Don't try to build on arm
 ExcludeArch: %{arm}
@@ -37,6 +40,7 @@ BuildRequires:  libXv-devel
 BuildRequires:  libXmu-devel
 BuildRequires:  jack-audio-connection-kit-devel
 BuildRequires:  libass-devel
+BuildRequires:  libmp4v2-devel
 
 # Sound out
 BuildRequires:  alsa-lib-devel >= 1.0.3
@@ -119,12 +123,15 @@ This package contains translation files for %{name}.
 %prep
 %setup -q -n %{name}_%{version}
 %patch0 -p1
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
 
 # Remove sources of bundled libraries.
 rm -rf avidemux_plugins/ADM_audioDecoders/ADM_ad_ac3/ADM_liba52 \
        avidemux_plugins/ADM_audioDecoders/ADM_ad_mad/ADM_libMad \
-       avidemux_plugins/ADM_audioEncoders/twolame/ADM_libtwolame \
-       avidemux_plugins/ADM_videoFilters6/ass/ADM_libass
+       avidemux_plugins/ADM_videoFilters6/ass/ADM_libass \
+       avidemux_plugins/ADM_muxers/muxerMp4v2/libmp4v2
 
 %build
 # Build avidemux_core
@@ -168,7 +175,7 @@ rm -rf build_plugins_common && mkdir build_plugins_common && pushd build_plugins
        -DUSE_EXTERNAL_LIBASS=TRUE \
        -DUSE_EXTERNAL_LIBMAD=TRUE \
        -DUSE_EXTERNAL_LIBA52=TRUE \
-       -DUSE_EXTERNAL_TWOLAME=TRUE \
+       -DUSE_EXTERNAL_MP4V2=TRUE \
        ../avidemux_plugins
 make %{?_smp_mflags}
 make install DESTDIR=%{_pkgbuilddir}/fakeRoot
@@ -184,7 +191,7 @@ rm -rf build_plugins_cli && mkdir build_plugins_cli && pushd build_plugins_cli
        -DUSE_EXTERNAL_LIBASS=TRUE \
        -DUSE_EXTERNAL_LIBMAD=TRUE \
        -DUSE_EXTERNAL_LIBA52=TRUE \
-       -DUSE_EXTERNAL_TWOLAME=TRUE \
+       -DUSE_EXTERNAL_MP4V2=TRUE \
        ../avidemux_plugins
 make %{?_smp_mflags}
 make install DESTDIR=%{_pkgbuilddir}/fakeRoot
@@ -200,7 +207,7 @@ rm -rf build_plugins_qt5 && mkdir build_plugins_qt5 && pushd build_plugins_qt5
        -DUSE_EXTERNAL_LIBASS=TRUE \
        -DUSE_EXTERNAL_LIBMAD=TRUE \
        -DUSE_EXTERNAL_LIBA52=TRUE \
-       -DUSE_EXTERNAL_TWOLAME=TRUE \
+       -DUSE_EXTERNAL_MP4V2=TRUE \
        ../avidemux_plugins
 make %{?_smp_mflags}
 make install DESTDIR=%{_pkgbuilddir}/fakeRoot


### PR DESCRIPTION
Warning: Please bump the release if appropriate and add a changelog entry.

The biggest issues with the brand-new filter preview dialog have been resolved upstream, the 4 relevant commits are merged into `avidemux-2.6.16-filter-preview.patch`, the headers preserved.

The patch to unbundle libmp4v2 has been just submitted for inclusion upstream, not yet merged. It saves ~1 MiB of installed size, no issues with the system libmp4v2 spotted (the bundled lib was not patched, despite a folder named `patches`). Build dep on libmp4v2-devel added.

The SPEC file was setting a cmake variable to use system twolame, which has become obsolete since Avidemux doesn't bundle twolame. This variable is removed.

Finally, `avidemux-2.6.16-mp4muxer-eac3.patch` allows muxing E-AC3 soundtracks with the MP4 muxer. This is a minimal isolated zero risk fix which would be nice to include downstream.