### PR TITLE
Add AppData support, to have Avidemux installable from software centers

### DIFF
--- a/avidemux-qt.appdata.xml
+++ b/avidemux-qt.appdata.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Adrien Vergé -->
+<component type="desktop-application">
+    <id>rpmfusion-avidemux-qt.desktop</id>
+    <metadata_license>CC0</metadata_license>
+    <name>Avidemux</name>
+    <summary>Multi-purpose video editing and processing software</summary>
+    <description>
+        <p>
+            Avidemux is a free open-source program designed for multi-purpose
+            video editing and processing, which can be used on almost all known
+            operating systems and computer platforms.
+        </p>
+    </description>
+    <categories>
+        <category>AudioVideo</category>
+        <category>AudioVideoEditing</category>
+        <category>Video</category>
+    </categories>
+    <url type="homepage">https://www.avidemux.org/</url>
+    <provides>
+        <binary>avidemux3_qt5</binary>
+        <binary>avidemux3_jobs_qt5</binary>
+    </provides>
+    <project_license>GPL-2.0+</project_license>
+    <update_contact>Avidemux team -- avidemux.org/smif/</update_contact>
+    <screenshots>
+        <screenshot type="default">http://fixounet.free.fr/avidemux/index_files/screenshot1.png</screenshot>
+        <screenshot type="default">http://fixounet.free.fr/avidemux/index_files/screenshot2.png</screenshot>
+    </screenshots>
+</component>

--- a/avidemux.spec
+++ b/avidemux.spec
@@ -5,13 +5,14 @@
 
 Name:           avidemux
 Version:        2.6.16
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Graphical video editing and transcoding tool
 
 License:        GPLv2+
 URL:            http://www.avidemux.org
 Source0:        http://downloads.sourceforge.net/%{name}/%{name}_%{version}.tar.gz
 Source1:        avidemux-qt.desktop
+Source2:        avidemux-qt.appdata.xml
 
 Patch0:         avidemux-2.6.15-disable-vpx-decoder-plugin.patch
 Patch1:         avidemux-2.6.16-filter-preview.patch
@@ -29,6 +30,7 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  pkgconfig
 BuildRequires:  sqlite-devel
 BuildRequires:  bzip2
+BuildRequires:  libappstream-glib
 
 # Libraries
 BuildRequires:  yasm-devel
@@ -233,6 +235,12 @@ desktop-file-install --vendor rpmfusion \
     --dir %{buildroot}%{_datadir}/applications \
     %{SOURCE1}
 
+# Appdata for software center
+install -pDm 0644 %{SOURCE2} \
+    %{buildroot}%{_datadir}/appdata/avidemux-qt.appdata.xml
+appstream-util validate-relax --nonet \
+    %{buildroot}%{_datadir}/appdata/avidemux-qt.appdata.xml || :
+
 # Install icons
 install -pDm 0644 avidemux/gtk/ADM_userInterfaces/glade/main/avidemux_icon_small.png \
         %{buildroot}%{_datadir}/icons/hicolor/48x48/apps/avidemux.png
@@ -296,6 +304,7 @@ fi
 %{_libdir}/libADM_UIQT*.so
 %{_libdir}/libADM_render6_QT5.so
 %{_datadir}/applications/rpmfusion-avidemux-qt.desktop
+%{_datadir}/appdata/avidemux-qt.appdata.xml
 # QT plugins
 %{_libdir}/ADM_plugins6/videoEncoders/qt5/
 %{_libdir}/ADM_plugins6/videoFilters/qt5/
@@ -306,6 +315,10 @@ fi
 
 
 %changelog
+* Sun Feb 12 2017 Adrien Vergé <adrienverge@gmail.com> - 2.6.16-4
+- Add AppData support, to have Avidemux installable from software centers
+  (see http://people.freedesktop.org/~hughsient/appdata/)
+
 * Tue Jan  3 2017 Richard Shaw <hobbes1069@gmail.com> - 2.6.16-3
 - Disable byte-compiling of python scrips as they are designed to be 
   interpreted internally.


### PR DESCRIPTION
AppData files are a standard to describe GUI applications. In particular, they allow these applications to be searched for and installed through software centers.

This commit embeds a `.appdata.xml` file for Avidemux, so my grandmother can install it without having to open a terminal.

Reference: https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps